### PR TITLE
chore: pin GitHub Actions versions to commit hashes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up MySQL container
       run: |
         docker compose -f docker-compose.yml up -d
 
-    - uses: isbang/compose-action@v1.4.1
+    - uses: isbang/compose-action@8be2d741e891ac9b8ac20825e6f3904149599925 # v2.2.0
   
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4.6.0
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
This will help prevent attacks such as [this one](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/).

Dependabot is able to update these versions automatically, and it will preserve the readable version comments.
